### PR TITLE
Fix .update() uses this.props instead of newProps

### DIFF
--- a/src/Control.js
+++ b/src/Control.js
@@ -60,7 +60,7 @@ export class Control extends React.Component {
       events: prevEvents,
     } = separateEvents(prevProps);
 
-    const { data, options, state, events } = separateEvents(this.props);
+    const { data, options, state, events } = separateEvents(newProps);
 
     if (data !== prevData) {
       instance.data.set(data);


### PR DESCRIPTION
В момент апдэйта `this.props` еще содержит старые пропсы, идентичные `prevProps`. Свежие пропсы нужно брать из `newProps`.

Этой ошибки можно было бы избежать, если бы в конфиге eslint'a правило `no-unused-vars` стояло бы в `error`, а не `warn`. Тогда линтер сругался бы на неиспользованные `newProps`.