### PR TITLE
Yandex Maps API key is "apikey"

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,15 @@ const MyPlacemark = () => (
 
 ## Enterprise
 
-```bash
-    <YMaps
-        // ...
-        enterprise={ true }
-        query={{
-            apikey: '// your api key here',
-        }}
-        // ...
-    />
+`react-yandex-maps` library also supports enterprise version of Yandex.Maps API:
+
+```jsx
+  <YMaps
+    enterprise
+    query={{
+      apikey: '// your api key here',
+    }}
+  />
 ```
 
 ## Events

--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ const MyPlacemark = () => (
 );
 ```
 
+## Enterprise
+
+```bash
+    <YMaps
+        // ...
+        enterprise={ true }
+        query={{
+            apikey: '// your api key here',
+        }}
+        // ...
+    />
+```
+
 ## Events
 
 All Objects events are available, just use camelCase event names instead of

--- a/src/YMaps.js
+++ b/src/YMaps.js
@@ -15,7 +15,7 @@ export class YMaps extends React.Component {
 
     query: shape({
       lang: string,
-      apiKey: string,
+      apikey: string,
       coordorder: oneOf(['latlong', 'longlat']),
       load: string,
       mode: oneOf(['debug', 'release']),


### PR DESCRIPTION
Test:

https://enterprise.api-maps.yandex.ru/2.1/?lang=ru_RU&lang=ru-RU&onload=__react-yandex-maps-onload&onerror=__react-yandex-maps-onerror&apiKey=<secret\>

returns "Missing API key"

https://enterprise.api-maps.yandex.ru/2.1/?lang=ru_RU&lang=ru-RU&onload=__react-yandex-maps-onload&onerror=__react-yandex-maps-onerror&apikey=<secret\>

ok