### PR TITLE
Change file name to m.js when creating es module distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Yandex.Maps API bindings for React",
   "main": "dist/react-yandex-maps.js",
   "umd:main": "dist/react-yandex-maps.umd.js",
-  "module": "dist/react-yandex-maps.mjs",
+  "module": "dist/react-yandex-maps.m.js",
   "source": "src/index.js",
   "files": [
     "README.md",


### PR DESCRIPTION
`.mjs` file extensions are not handled by CRA properly, this PR fixes the issue