### PR TITLE
Change build to rollup + babel 7

### DIFF
--- a/docs/components/LiveEditor.js
+++ b/docs/components/LiveEditor.js
@@ -6,7 +6,7 @@ import styled from 'react-emotion';
 import { Flex, Box, Switch, Label } from 'rebass/emotion';
 import * as ReactLive from 'react-live';
 
-import * as scope from '../../dist/react-yandex-maps';
+import * as scope from '../../dist/react-yandex-maps.esm';
 import features from '../app-data/features';
 import points from '../app-data/points';
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,9 @@
   "name": "react-yandex-maps",
   "version": "3.0.1",
   "description": "Yandex.Maps API bindings for React",
-  "main": "dist/react-yandex-maps.js",
-  "umd:main": "dist/react-yandex-maps.umd.js",
-  "module": "dist/react-yandex-maps.m.js",
-  "source": "src/index.js",
+  "main": "dist/react-yandex-maps.cjs.js",
+  "module": "dist/react-yandex-maps.esm.js",
+  "browser": "dist/react-yandex-maps.umd.production.min.js",
   "files": [
     "README.md",
     "LICENSE",
@@ -15,10 +14,7 @@
     "clear": "rm -rf dist",
     "prettier": "prettier --write",
     "lint": "eslint",
-    "microbundle": "microbundle --jsx React.createElement --name ReactYandexMaps --target web --strict true --external react",
-    "build": "npm run clear && npm run microbundle && npm run umd:globals && npm run umd:prod",
-    "umd:globals": "sed -i'.tmp' 's/\\.react/\\.React/g' \"dist/react-yandex-maps.umd.js\"",
-    "umd:prod": "terser --source-map --compress --define process.env.NODE_ENV='\"production\"' --output dist/react-yandex-maps.umd.js -- dist/react-yandex-maps.umd.js ",
+    "build": "npm run clear && NODE_ENV=development rollup -c && NODE_ENV=production rollup -c",
     "dev": "microbundle watch --jsx React.createElement --target web --strict true --compress false",
     "release": "./scripts/release.sh",
     "test": "jest"
@@ -36,6 +32,9 @@
     "react-display-name": "^0.2.4"
   },
   "devDependencies": {
+    "@babel/core": "^7.1.2",
+    "@babel/preset-env": "^7.1.0",
+    "@babel/preset-react": "^7.0.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.6",
     "babel-jest": "^23.4.2",
@@ -47,9 +46,14 @@
     "husky": "^1.0.0-rc.13",
     "jest": "^23.5.0",
     "lint-staged": "^7.2.2",
-    "microbundle": "^0.6.0",
     "prettier": "github:prettier/prettier",
     "react": "^16.4.2",
+    "rollup": "^0.66.4",
+    "rollup-plugin-babel": "^4.0.3",
+    "rollup-plugin-commonjs": "^9.1.8",
+    "rollup-plugin-node-resolve": "^3.4.0",
+    "rollup-plugin-replace": "^2.0.0",
+    "rollup-plugin-terser": "^3.0.0",
     "terser": "^3.9.2"
   },
   "keywords": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,65 @@
+const path = require('path');
+
+const babel = require('rollup-plugin-babel');
+const commonjs = require('rollup-plugin-commonjs');
+const nodeResolve = require('rollup-plugin-node-resolve');
+const { terser } = require('rollup-plugin-terser');
+const replace = require('rollup-plugin-replace');
+
+const { name, peerDependencies } = require('./package.json');
+
+const NODE_ENV = process.env.NODE_ENV || 'production';
+
+const formats = ['cjs', 'esm', 'umd'];
+
+const outputs = formats.map(format => ({
+  file: [
+    name,
+    format,
+    NODE_ENV === 'production' ? 'production.min' : false,
+    'js',
+  ]
+    .filter(Boolean)
+    .join('.'),
+  dir: path.resolve(__dirname, 'dist'),
+  format: format,
+  sourcemap: NODE_ENV === 'production',
+  globals: {
+    react: 'React',
+  },
+  ...(format === 'umd' && { name: 'ReactYandexMaps' }),
+}));
+
+const commonConfig = {
+  input: path.resolve(__dirname, 'src/index.js'),
+  plugins: [
+    NODE_ENV === 'production' &&
+      replace({
+        'process.env.NODE_ENV': JSON.stringify(NODE_ENV),
+      }),
+
+    babel({
+      exclude: 'node_modules/**',
+      babelrc: false,
+      presets: [
+        require.resolve('@babel/preset-env'),
+        require.resolve('@babel/preset-react'),
+      ],
+    }),
+
+    commonjs({
+      include: 'node_modules/**',
+    }),
+
+    nodeResolve({
+      module: true,
+      jsnext: true,
+      browser: true,
+    }),
+
+    NODE_ENV === 'production' && terser(),
+  ].filter(Boolean),
+  external: Object.keys(peerDependencies),
+};
+
+module.exports = outputs.map(output => ({ ...commonConfig, output }));

--- a/umd-example.html
+++ b/umd-example.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+  <title>ReactYandexMaps with UMD module example</title>
+
+  <script src="https://unpkg.com/react/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
+
+  <script src="./dist/react-yandex-maps.umd.production.min.js"></script>
+</head>
+
+<body>
+  <div id="root"></div>
+
+  <script>
+    const { YMaps, Map: MapObject } = ReactYandexMaps;
+    const h = React.createElement;
+
+    const App = () =>
+      h(
+        YMaps,
+        {},
+        h(
+          "div",
+          {},
+          "My awesome application with maps!",
+          h(MapObject, { defaultState: { center: [55.75, 37.57], zoom: 9 } })
+        )
+      );
+
+    ReactDOM.render(h(App), document.getElementById("root"));
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
There were a couple of issues reported where the library wasn't working when imported in `create-react-app@2` application. It was really hard to track the issue, as it wasn't easily reproduced, but it seems like switching from microbundle to rollup solves it somehow. For further investigation, any v3 release before this commit/release could be used.