### PR TITLE
Added basic TypeScript typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 !.npmrc
 !.travis.yml
 
+yarn.lock
 package-lock.json
 npm-shrinkwrap.json
 coverage

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "react-yandex-maps",
   "version": "3.0.2",
   "description": "Yandex.Maps API bindings for React",
+  "typings": "typings/index.d.ts",
   "main": "dist/react-yandex-maps.cjs.js",
   "module": "dist/react-yandex-maps.esm.js",
   "browser": "dist/react-yandex-maps.umd.production.min.js",
   "files": [
     "README.md",
     "LICENSE",
-    "dist"
+    "dist",
+    "typings"
   ],
   "scripts": {
     "clear": "rm -rf dist",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -188,7 +188,7 @@ export interface WithYMapsProps {
 export function withYMaps<P>(
   component: React.ComponentType<P>,
   waitForApi?: boolean,
-  modules?: string
+  modules?: string[]
 ): React.ComponentType<P & WithYMapsProps>;
 
 export const YMaps: React.ComponentType<YMapsProps>;
@@ -258,8 +258,8 @@ export type TypeSelectorProps<
   O = AnyObject,
   S = AnyObject
 > = ControlProps<D, O, S> & {
-  mapTypes?: MapType;
-  defaultMapTypes?: MapType;
+  mapTypes?: MapType[];
+  defaultMapTypes?: MapType[];
 };
 
 export const Button: React.ComponentType<ControlProps>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -174,6 +174,16 @@ export interface GeoObjectGeometry {
   radius: number;
 }
 
+export interface WithYMapsProps {
+  ymaps: YMapsApi;
+}
+
+export function withYMaps<P>(
+  component: React.ComponentType<P>,
+  waitForApi?: boolean,
+  modules?: string
+): React.ComponentType<P & WithYMapsProps>;
+
 export type PlacemarkGeometry = number[];
 export type PolylineGeometry = number[][];
 export type RectangleGeometry = number[][];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -168,10 +168,14 @@ export interface GeoObjectProps<G, P = AnyObject, O = AnyObject>
   defaultOptions?: O;
 }
 
-export interface GeoObjectGeometry {
-  type: 'Point' | 'LineString' | 'Rectangle' | 'Polygon' | 'Circle';
-  coordinates: number[] | number[][] | number[][][];
-  radius: number;
+export interface ControlProps<D = AnyObject, O = AnyObject, S = AnyObject>
+  extends CommonProps {
+  data?: D;
+  defaultData?: D;
+  options?: O;
+  defaultOptions?: O;
+  state?: S;
+  defaultState?: S;
 }
 
 export interface WithYMapsProps {
@@ -184,6 +188,13 @@ export function withYMaps<P>(
   modules?: string
 ): React.ComponentType<P & WithYMapsProps>;
 
+// export interface GeoObjectGeometry {
+//   type: 'Point' | 'LineString' | 'Rectangle' | 'Polygon' | 'Circle';
+//   coordinates: number[] | number[][] | number[][][];
+//   radius: number;
+// }
+
+export type GeoObjectGeometry = AnyObject;
 export type PlacemarkGeometry = number[];
 export type PolylineGeometry = number[][];
 export type RectangleGeometry = number[][];
@@ -204,18 +215,18 @@ export const Polygon: React.ComponentType<GeoObjectProps<PolygonGeometry>>;
 export const Circle: React.ComponentType<GeoObjectProps<CircleGeometry>>;
 
 /**
- * TODO: need more information about prop types
+ * TODO: data, options, state types for controls
  */
-export const Button: React.ComponentType<AnyObject>;
-export const FullscreenControl: React.ComponentType<AnyObject>;
-export const GeolocationControl: React.ComponentType<AnyObject>;
-export const ListBox: React.ComponentType<AnyObject>;
-export const ListBoxItem: React.ComponentType<AnyObject>;
-export const RouteButton: React.ComponentType<AnyObject>;
-export const RouteEditor: React.ComponentType<AnyObject>;
+export const Button: React.ComponentType<ControlProps>;
+export const FullscreenControl: React.ComponentType<ControlProps>;
+export const GeolocationControl: React.ComponentType<ControlProps>;
+export const ListBox: React.ComponentType<ControlProps>;
+export const ListBoxItem: React.ComponentType<ControlProps>;
+export const RouteButton: React.ComponentType<ControlProps>;
+export const RouteEditor: React.ComponentType<ControlProps>;
 export const RoutePanel: React.ComponentType<AnyObject>;
-export const RulerControl: React.ComponentType<AnyObject>;
-export const SearchControl: React.ComponentType<AnyObject>;
+export const RulerControl: React.ComponentType<ControlProps>;
+export const SearchControl: React.ComponentType<ControlProps>;
 export const TrafficControl: React.ComponentType<AnyObject>;
 export const TypeSelector: React.ComponentType<AnyObject>;
-export const ZoomControl: React.ComponentType<AnyObject>;
+export const ZoomControl: React.ComponentType<ControlProps>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,14 +29,39 @@ export interface YMapsProps extends AnyObject {
   preload?: boolean;
 }
 
-export interface MapState extends AnyObject {
-  bounds?: number[][];
-  center?: number[];
+interface MapStateBase extends AnyObject {
   controls?: string[];
   behaviors?: string[];
   margin?: number[] | number[][];
   type?: 'yandex#map' | 'yandex#satellite' | 'yandex#hybrid';
+}
+
+/**
+ * REVIEW: disccuss if this behavior is necessary
+ */
+
+// interface MapStateBounds {
+//   bounds: number[][];
+//   zoom?: never;
+//   center?: never;
+// }
+
+// interface MapStateCenter {
+//   center: number[];
+//   zoom: number;
+//   bounds?: never;
+// }
+
+// export type MapState = MapStateBase & (MapStateBounds | MapStateCenter);
+
+interface MapState extends MapStateBase {
+  center?: number[];
   zoom?: number;
+  bounds?: number[][];
+  controls?: string[];
+  behaviors?: string[];
+  margin?: number[] | number[][];
+  type?: 'yandex#map' | 'yandex#satellite' | 'yandex#hybrid';
 }
 
 export interface MapOptions extends AnyObject {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 interface AnyObject {
   [key: string]: any;
 }
@@ -55,7 +53,7 @@ export interface MapProps extends AnyObject {
   defaultState?: MapState;
   options?: MapOptions;
   defaultOptions?: MapOptions;
-  children?: ReactNode;
+  children?: React.ReactNode;
   width?: number | string;
   height?: number | string;
   style?: React.CSSProperties;
@@ -141,6 +139,12 @@ export interface GeoObjectProps<G, P = AnyObject, O = AnyObject>
   options?: O;
   defaultOptions?: O;
 }
+
+export type GeoObjectGeometry = {
+  type: 'Point' | 'LineString' | 'Rectangle' | 'Polygon' | 'Circle';
+  coordinates: number[] | number[][] | number[][][];
+  radius: number;
+};
 
 export type PlacemarkGeometry = number[];
 export type PolylineGeometry = number[][];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,7 +2,7 @@ interface AnyObject {
   [key: string]: any;
 }
 
-export type YMapsApi = AnyObject;
+export interface YMapsApi extends AnyObject {}
 
 export interface YMapsProps extends AnyObject {
   version?: string;
@@ -53,6 +53,7 @@ export interface MapProps extends AnyObject {
   defaultState?: MapState;
   options?: MapOptions;
   defaultOptions?: MapOptions;
+  modules?: string[];
   children?: React.ReactNode;
   width?: number | string;
   height?: number | string;
@@ -78,7 +79,9 @@ export type ObjectManagerFeatures =
   | (ObjectManagerFeatureCollection | ObjectManagerFeature)[]
   | ObjectManagerFeatureCollection;
 
-export type ObjectManagerFilter = string | ((...args: any[]) => any);
+export type ObjectManagerFilter =
+  | string
+  | ((feature: ObjectManagerFeature) => void);
 
 export interface ObjectManagerOptions extends AnyObject {
   clusterize?: boolean;
@@ -130,6 +133,30 @@ export interface ClustererProps extends AnyObject {
   instanceRef?: (instance: any) => void;
 }
 
+export interface PanoramaOptions extends AnyObject {
+  autoFitToViewport?: 'none' | 'ifNull' | 'always';
+  controls?: string[];
+  direction?: number[] | string;
+  hotkeysEnabled?: boolean;
+  scrollZoomBehavior?: boolean;
+  span?: string | number[];
+  suppressMapOpenBlock?: boolean;
+}
+
+export interface PanoramaProps extends AnyObject {
+  coordinates?: number[];
+  defaultCoordinates?: number[];
+  options?: PanoramaOptions;
+  defaultOptions?: PanoramaOptions;
+  modules?: string[];
+  children?: React.ReactNode;
+  width?: number | string;
+  height?: number | string;
+  style?: React.CSSProperties;
+  className?: string;
+  instanceRef?: (instance: any) => void;
+}
+
 export interface GeoObjectProps<G, P = AnyObject, O = AnyObject>
   extends AnyObject {
   geometry?: G;
@@ -140,11 +167,11 @@ export interface GeoObjectProps<G, P = AnyObject, O = AnyObject>
   defaultOptions?: O;
 }
 
-export type GeoObjectGeometry = {
+export interface GeoObjectGeometry {
   type: 'Point' | 'LineString' | 'Rectangle' | 'Polygon' | 'Circle';
   coordinates: number[] | number[][] | number[][][];
   radius: number;
-};
+}
 
 export type PlacemarkGeometry = number[];
 export type PolylineGeometry = number[][];
@@ -156,6 +183,7 @@ export const YMaps: React.ComponentType<YMapsProps>;
 export const Map: React.ComponentType<MapProps>;
 export const ObjectManager: React.ComponentType<ObjectManagerProps>;
 export const Clusterer: React.ComponentType<ClustererProps>;
+export const Panorama: React.ComponentType<PanoramaProps>;
 
 export const GeoObject: React.ComponentType<GeoObjectProps<GeoObjectGeometry>>;
 export const Placemark: React.ComponentType<GeoObjectProps<PlacemarkGeometry>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,178 @@
+import * as React from 'react';
+
+interface AnyObject {
+  [key: string]: any;
+}
+
+export type YMapsApi = AnyObject;
+
+export interface YMapsProps extends AnyObject {
+  version?: string;
+  enterprise?: boolean;
+  query?: {
+    lang?: 'tr_TR' | 'en_US' | 'en_RU' | 'ru_RU' | 'ru_UA' | 'uk_UA';
+    apikey?: string;
+    coordorder?: 'latlong' | 'longlat';
+    load?: string;
+    mode?: 'release' | 'debug';
+    csp?: boolean;
+    ns?: string;
+  };
+  children?: React.ReactNode;
+  preload?: boolean;
+}
+
+export interface MapState extends AnyObject {
+  bounds?: number[][];
+  center?: number[];
+  controls?: string[];
+  behaviors?: string[];
+  margin?: number[] | number[][];
+  type?: 'yandex#map' | 'yandex#satellite' | 'yandex#hybrid';
+  zoom?: number;
+}
+
+export interface MapOptions extends AnyObject {
+  autoFitToViewport?: 'none' | 'ifNull' | 'always';
+  avoidFractionalZoom?: boolean;
+  exitFullscreenByEsc?: boolean;
+  fullscreenZIndex?: number;
+  mapAutoFocus?: boolean;
+  maxAnimationZoomDifference?: number;
+  maxZoom?: number;
+  minZoom?: number;
+  nativeFullscreen?: boolean;
+  projection?: any;
+  restrictMapArea?: boolean;
+  suppressMapOpenBlock?: boolean;
+  suppressObsoleteBrowserNotifier?: boolean;
+  yandexMapAutoSwitch?: boolean;
+  yandexMapDisablePoiInteractivity?: boolean;
+}
+
+export interface MapProps extends AnyObject {
+  state?: MapState;
+  defaultState?: MapState;
+  options?: MapOptions;
+  defaultOptions?: MapOptions;
+  children?: ReactNode;
+  width?: number | string;
+  height?: number | string;
+  style?: React.CSSProperties;
+  className?: string;
+  instanceRef?: (instance: any) => void;
+}
+
+export interface ObjectManagerFeature {
+  id: number | string;
+  type: 'Feature';
+  geometry: AnyObject;
+  options?: AnyObject;
+  properties?: AnyObject;
+}
+
+export interface ObjectManagerFeatureCollection {
+  type: 'FeatureCollection';
+  features: (ObjectManagerFeatureCollection | ObjectManagerFeature)[];
+}
+
+export type ObjectManagerFeatures =
+  | (ObjectManagerFeatureCollection | ObjectManagerFeature)[]
+  | ObjectManagerFeatureCollection;
+
+export type ObjectManagerFilter = string | ((...args: any[]) => any);
+
+export interface ObjectManagerOptions extends AnyObject {
+  clusterize?: boolean;
+  syncOverlayInit?: boolean;
+  viewportMargin?: number | number[];
+}
+
+/**
+ * FIXME:
+ */
+export type ObjectManagerObjectsOptions = AnyObject;
+export type ObjectManagerClustersOptions = AnyObject;
+
+export interface ObjectManagerProps {
+  features?: ObjectManagerFeatures;
+  defaultFeatures?: ObjectManagerFeatures;
+  filter?: ObjectManagerFilter;
+  defaultFilter?: ObjectManagerFilter;
+  options?: ObjectManagerOptions;
+  defaultOptions?: ObjectManagerOptions;
+  objects?: ObjectManagerObjectsOptions;
+  defaultObjects?: ObjectManagerObjectsOptions;
+  clusters?: ObjectManagerClustersOptions;
+  defaultClusters?: ObjectManagerClustersOptions;
+  parent?: any;
+  instanceRef?: (instance: any) => void;
+}
+
+export interface ClustererOptions extends AnyObject {
+  gridSize?: number;
+  groupByCoordinates?: boolean;
+  hasBalloon?: boolean;
+  hasHint?: boolean;
+  margin?: number | number[] | number[][];
+  maxZoom?: number | number[];
+  minClusterSize?: number;
+  preset?: string;
+  showInAlphabeticalOrder?: boolean;
+  useMapMargin?: boolean;
+  viewportMargin?: number | number[] | number[][];
+  zoomMargin?: number | number[] | number[][];
+}
+
+export interface ClustererProps extends AnyObject {
+  options?: ClustererOptions;
+  defaultOptions?: ClustererOptions;
+  children?: React.ReactNode;
+  parent?: any;
+  instanceRef?: (instance: any) => void;
+}
+
+export interface GeoObjectProps<G, P = AnyObject, O = AnyObject>
+  extends AnyObject {
+  geometry?: G;
+  defaultGeometry?: G;
+  properties?: P;
+  defaultProperties?: P;
+  options?: O;
+  defaultOptions?: O;
+}
+
+export type PlacemarkGeometry = number[];
+export type PolylineGeometry = number[][];
+export type RectangleGeometry = number[][];
+export type PolygonGeometry = number[][][];
+export type CircleGeometry = (number | number[])[];
+
+export const YMaps: React.ComponentType<YMapsProps>;
+export const Map: React.ComponentType<MapProps>;
+export const ObjectManager: React.ComponentType<ObjectManagerProps>;
+export const Clusterer: React.ComponentType<ClustererProps>;
+
+export const GeoObject: React.ComponentType<GeoObjectProps<GeoObjectGeometry>>;
+export const Placemark: React.ComponentType<GeoObjectProps<PlacemarkGeometry>>;
+export const Polyline: React.ComponentType<GeoObjectProps<PolylineGeometry>>;
+export const Rectangle: React.ComponentType<GeoObjectProps<RectangleGeometry>>;
+export const Polygon: React.ComponentType<GeoObjectProps<PolygonGeometry>>;
+export const Circle: React.ComponentType<GeoObjectProps<CircleGeometry>>;
+
+/**
+ * TODO: need more information about prop types
+ */
+export const Button: React.ComponentType<AnyObject>;
+export const FullscreenControl: React.ComponentType<AnyObject>;
+export const GeolocationControl: React.ComponentType<AnyObject>;
+export const ListBox: React.ComponentType<AnyObject>;
+export const ListBoxItem: React.ComponentType<AnyObject>;
+export const RouteButton: React.ComponentType<AnyObject>;
+export const RouteEditor: React.ComponentType<AnyObject>;
+export const RoutePanel: React.ComponentType<AnyObject>;
+export const RulerControl: React.ComponentType<AnyObject>;
+export const SearchControl: React.ComponentType<AnyObject>;
+export const TrafficControl: React.ComponentType<AnyObject>;
+export const TypeSelector: React.ComponentType<AnyObject>;
+export const ZoomControl: React.ComponentType<AnyObject>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,14 @@
+import * as React from 'react';
+
 interface AnyObject {
   [key: string]: any;
+}
+
+interface CommonProps<T = any> {
+  instanceRef?: (ref: React.Ref<T>) => void;
+  onLoad?: (ymaps: YMapsApi) => void;
+  onError?: (error: Error) => void;
+  modules?: string[];
 }
 
 export interface YMapsApi extends AnyObject {}
@@ -48,18 +57,16 @@ export interface MapOptions extends AnyObject {
   yandexMapDisablePoiInteractivity?: boolean;
 }
 
-export interface MapProps extends AnyObject {
+export interface MapProps extends CommonProps {
   state?: MapState;
   defaultState?: MapState;
   options?: MapOptions;
   defaultOptions?: MapOptions;
-  modules?: string[];
   children?: React.ReactNode;
   width?: number | string;
   height?: number | string;
   style?: React.CSSProperties;
   className?: string;
-  instanceRef?: (instance: any) => void;
 }
 
 export interface ObjectManagerFeature {
@@ -95,7 +102,7 @@ export interface ObjectManagerOptions extends AnyObject {
 export type ObjectManagerObjectsOptions = AnyObject;
 export type ObjectManagerClustersOptions = AnyObject;
 
-export interface ObjectManagerProps {
+export interface ObjectManagerProps extends CommonProps {
   features?: ObjectManagerFeatures;
   defaultFeatures?: ObjectManagerFeatures;
   filter?: ObjectManagerFilter;
@@ -106,8 +113,6 @@ export interface ObjectManagerProps {
   defaultObjects?: ObjectManagerObjectsOptions;
   clusters?: ObjectManagerClustersOptions;
   defaultClusters?: ObjectManagerClustersOptions;
-  parent?: any;
-  instanceRef?: (instance: any) => void;
 }
 
 export interface ClustererOptions extends AnyObject {
@@ -125,12 +130,10 @@ export interface ClustererOptions extends AnyObject {
   zoomMargin?: number | number[] | number[][];
 }
 
-export interface ClustererProps extends AnyObject {
+export interface ClustererProps extends CommonProps {
   options?: ClustererOptions;
   defaultOptions?: ClustererOptions;
   children?: React.ReactNode;
-  parent?: any;
-  instanceRef?: (instance: any) => void;
 }
 
 export interface PanoramaOptions extends AnyObject {
@@ -143,18 +146,16 @@ export interface PanoramaOptions extends AnyObject {
   suppressMapOpenBlock?: boolean;
 }
 
-export interface PanoramaProps extends AnyObject {
+export interface PanoramaProps extends CommonProps {
   coordinates?: number[];
   defaultCoordinates?: number[];
   options?: PanoramaOptions;
   defaultOptions?: PanoramaOptions;
-  modules?: string[];
   children?: React.ReactNode;
   width?: number | string;
   height?: number | string;
   style?: React.CSSProperties;
   className?: string;
-  instanceRef?: (instance: any) => void;
 }
 
 export interface GeoObjectProps<G, P = AnyObject, O = AnyObject>


### PR DESCRIPTION
Fixes #63 

These typings are basic which I could get with components `propTypes` information and [Maps API Documentation](https://tech.yandex.com/maps/jsapi/doc/2.1/ref/concepts/About-docpage/).

This needs an improvement. I don't have enough information about all of `controls` components, because their `propTypes` are missing.

We should also have a discussion about detailed typings for such props as `options`, `geometry`, `properties`, etc.  Do we actually need to handle this or just provide basic information about components, not `Yandex.Maps` API.

Only main components are typed in detail now. I think that's the best option for this "wrapper" package, because there are no `Yandex.Maps` maintained typings at the moment and it seems to me that excessive details are unnecessary.

## Current components typings status:

⚠️ Listed components are still required to be reviewed, but checked ones are basic-typed. Confirmed components will be marked with bold, controversial will be marked with italic text.

### Main:
- [x] **YMaps**
- [x] **Map**
- [x] **Clusterer**
- [x] _ObjectManager_
- [x] **Panorama**
- [x] **withYMaps**

### Geo Objects:
- [x] **GeoObject**
- [x] **Placemark**
- [x] **Polyline**
- [x] **Rectangle**
- [x] **Polygon**
- [x] **Circle**

### Controls:
❓Components have simple definitions for `data`, `options`, `state` and optional individual fields, you can assign any `object` to them. We can make them more strict to every type of control, but does it even make sense? Opinions are welcome.
- [x] **Button**
- [x] **FullscreenControl**
- [x] **GeolocationControl**
- [x] **ListBox**
- [x] **ListBoxItem**
- [x] **RouteButton**
- [x] **RouteEditor**
- [x] **RoutePanel**
- [x] **RulerControl**
- [x] **SearchControl**
- [x] **TrafficControl**
- [x] **TypeSelector**
- [x] **ZoomControl**