### PR TITLE
Add Route component

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -23,6 +23,7 @@ module.exports = {
     'GeoObjects',
     'Clusterization',
     'Controls',
+    'Routes',
     'YMaps Context',
     'Migration Guide',
   ],

--- a/src/Route.js
+++ b/src/Route.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getProp, isControlledProp } from './util/props';
+import withYMaps from './withYMaps';
+import * as events from './util/events';
+import applyRef from './util/ref';
+import { withParentContext } from './Context';
+
+export class Route extends React.Component {
+  constructor() {
+    super();
+    this.state = { instance: null };
+  }
+
+  componentDidMount() {
+    Route.mountObject(this.props.ymaps.route, this.props).then(instance =>
+      this.setState({ instance })
+    );
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.state.instance !== null) {
+      Route.updateObject(this.state.instance, prevProps, this.props);
+    }
+  }
+
+  componentWillUnmount() {
+    Route.unmountObject(this.state.instance, this.props);
+  }
+
+  render() {
+    return null;
+  }
+
+  static mountObject(Route, props) {
+    const { instanceRef, parent, _events } = events.separateEvents(props);
+
+    const points = getProp(props, 'points');
+    const params = getProp(props, 'params');
+
+    return new Promise((resolve, reject) => {
+      Route(points, params).then(instance => {
+        if (
+          parent &&
+          parent.geoObjects &&
+          typeof parent.geoObjects.add === 'function'
+        ) {
+          parent.geoObjects.add(instance);
+        } else {
+          throw new Error(`No parent found to mount ${props.name}`);
+        }
+
+        applyRef(null, instanceRef, instance);
+
+        Object.keys(_events).forEach(key =>
+          events.addEvent(instance, key, _events[key])
+        );
+
+        resolve(instance);
+      }, reject);
+    });
+  }
+
+  static updateObject(instance, oldProps, newProps) {
+    const { _events: newEvents, instanceRef } = events.separateEvents(newProps);
+    const { _events: oldEvents, instanceRef: oldRef } = events.separateEvents(
+      oldProps
+    );
+
+    if (isControlledProp(newProps, 'params')) {
+      const oldOptions = getProp(oldProps, 'params');
+      const newOptions = getProp(newProps, 'params');
+
+      if (oldOptions !== newOptions) {
+        instance.options.set(newOptions);
+      }
+    }
+
+    events.updateEvents(instance, oldEvents, newEvents);
+
+    applyRef(oldRef, instanceRef, instance);
+  }
+
+  static unmountObject(instance, props) {
+    const { instanceRef, _events } = events.separateEvents(props);
+
+    if (instance !== null) {
+      Object.keys(_events).forEach(key =>
+        events.removeEvent(instance, key, _events[key])
+      );
+
+      // Clean used ref
+      applyRef(instanceRef);
+    }
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  Route.propTypes = {
+    /**
+     * The points for draw route
+     */
+    points: PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.number),
+        PropTypes.shape({
+          type: PropTypes.oneOf(['wayPoint', 'viaPoint']),
+          point: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.arrayOf(PropTypes.number),
+          ]),
+        }),
+      ])
+    ),
+
+    /**
+     * Route [params](https://tech.yandex.ru/maps/jsapi/doc/2.1/ref/reference/route-docpage/#route__param-params)
+     */
+    params: PropTypes.shape({}),
+
+    /**
+     * YMaps object ref
+     */
+    instanceRef: PropTypes.func,
+
+    ymaps: PropTypes.object,
+  };
+}
+
+export default withParentContext(withYMaps(Route, true, ['route']));

--- a/src/Route.mdx
+++ b/src/Route.mdx
@@ -1,0 +1,42 @@
+---
+name: Route
+route: /routes/route
+menu: Routes
+---
+
+import { Playground } from 'docz';
+import { Props } from '../docz/components/Props';
+import { Route as _Route } from './Route';
+import { YMaps, Map, Route } from './';
+
+# Route
+
+Renders Yandex.Maps API [Route][route] object
+
+## Basic Usage
+
+<Playground>
+  <YMaps query={{ apikey: '52512926-86c8-42a8-b561-e1fb75733b4a' }}>
+    <Map defaultState={{ center: [55.745508, 37.435225], zoom: 13 }}>
+      <Route
+        points={[
+          'Москва, улица Крылатские холмы',
+          {
+            point: 'Москва, метро Молодежная',
+            type: 'viaPoint',
+          },
+          [55.731272, 37.447198],
+          'Москва, метро Пионерская',
+        ]}
+        params={{ mapStateAutoApply: true }}
+      />
+    </Map>
+  </YMaps>
+</Playground>
+
+## Props
+
+<Props of={_Route} />
+
+[route]:
+  https://tech.yandex.ru/maps/jsapi/doc/2.1/ref/reference/router.Route-docpage/

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ export { default as Map } from './Map';
 
 export { default as Panorama } from './Panorama';
 
+export { default as Route } from './Route';
+
 /** Controls */
 
 export { default as Button } from './controls/Button';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -197,6 +197,8 @@ export const ObjectManager: React.ComponentType<ObjectManagerProps>;
 export const Clusterer: React.ComponentType<ClustererProps>;
 export const Panorama: React.ComponentType<PanoramaProps>;
 
+// TODO Add typing for Routes
+
 //
 // Geo Objects components
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Add basic [Route](https://tech.yandex.ru/maps/jsapi/doc/2.1/ref/reference/router.Route-docpage/) component implementation:
https://github.com/gribnoysup/react-yandex-maps/issues/15

I suppose this component will be very helpful, cause there are a lot of issues lying on it.

It will be nice to check it out.

I'll also try to add [MultiRoute](https://tech.yandex.ru/maps/jsapi/doc/2.1/ref/reference/multiRouter.MultiRoute-docpage/) support soon