### PR TITLE
Bugfix: withYMaps return type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -189,7 +189,7 @@ export function withYMaps<P>(
   component: React.ComponentType<P>,
   waitForApi?: boolean,
   modules?: string[]
-): React.ComponentType<P & WithYMapsProps>;
+): React.ComponentType<P>;
 
 export const YMaps: React.ComponentType<YMapsProps>;
 export const Map: React.ComponentType<MapProps>;


### PR DESCRIPTION
fix #181 

The current implementation return type of function `withYMaps` requires `ymaps` property. It`s wrong. This PR fix it.