### PR TITLE
Additional conditions to setCenter & setZoom.

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -103,11 +103,11 @@ export class Map extends React.Component {
         if (newState.behaviors) instance.behaviors.enable(newState.behaviors);
       }
 
-      if (oldState.zoom !== newState.zoom) {
+      if (newState.zoom && oldState.zoom !== newState.zoom) {
         instance.setZoom(newState.zoom);
       }
 
-      if (oldState.center !== newState.center) {
+      if (newState.center && oldState.center !== newState.center) {
         instance.setCenter(newState.center);
       }
 


### PR DESCRIPTION
In the case when you need to change mapState to use bounds instead of center / zoom, we should not call setCenter / setZoom, because they will have an undefined argument (this causes an error). In the reverse order everything works fine.