### PR TITLE
Fixed ObjectManager filter changing

### DIFF
--- a/src/clusterization/ObjectManager.js
+++ b/src/clusterization/ObjectManager.js
@@ -109,7 +109,7 @@ export class ObjectManager extends React.Component {
       const newFilter = getProp(newProps, 'filter');
 
       if (oldFilter !== newFilter) {
-        instance.options.set(newFilter);
+        instance.setFilter(newFilter);
       }
     }
 


### PR DESCRIPTION
After migrating from 2.3 I've found that ObjectManager filter changing code has stopped  fulfilling its duties. Investigation has shown that ```instance.options.set(newFilter)``` does absolutely nothing to change filter in this case. Code below fixes the problem.