### PR TITLE
Added default values for ObjectManagers props

### DIFF
--- a/src/clusterization/ObjectManager.js
+++ b/src/clusterization/ObjectManager.js
@@ -39,11 +39,11 @@ export class ObjectManager extends React.Component {
   static mountObject(ObjectManager, props) {
     const { instanceRef, parent, _events } = events.separateEvents(props);
 
-    const options = getProp(props, 'options');
-    const features = getProp(props, 'features');
-    const filter = getProp(props, 'filter');
-    const objects = getProp(props, 'objects');
-    const clusters = getProp(props, 'clusters');
+    const options = getProp(props, 'options', {});
+    const features = getProp(props, 'features', {});
+    const filter = getProp(props, 'filter', null);
+    const objects = getProp(props, 'objects', {});
+    const clusters = getProp(props, 'clusters', {});
 
     const instance = new ObjectManager(options);
 


### PR DESCRIPTION
'options',features','filter','objects','clusters' need default values because if we dont supply any value say to 'clusters' property we will get ```TypeError: cannot convert undefined or null to object``` in corresponding set method (see picture below)
![Screenshot_2](https://user-images.githubusercontent.com/16581315/80534152-0e3e7100-899f-11ea-906d-8a95b1381e5d.jpg)
