### PR TITLE
Add React 17 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "git+https://github.com/gribnoysup/react-yandex-maps.git"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.x || ^16.x"
+    "react": "^0.14.9 || ^15.x || ^16.x || ^17.x"
   },
   "dependencies": {
     "create-react-context": "^0.3.0",


### PR DESCRIPTION
See React 17 release blog post: https://reactjs.org/blog/2020/10/20/react-v17.html

I upgraded my project to this version and did not encounter any issues with `react-yandex-maps` after that. Adding React 17 to `peerDependencies` will help avoid this error in `yarn check`:

```txt
error "react-yandex-maps#react@^0.14.9 || ^15.x || ^16.x" doesn't satisfy found match of "react@17.0.1"
```