### PR TITLE
deps: move to mini-create-react-context

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react": "^0.14.9 || ^15.x || ^16.x || ^17.x"
   },
   "dependencies": {
-    "create-react-context": "^0.3.0",
+    "mini-create-react-context": "^0.4.1",
     "prop-types": "^15.7.2",
     "react-display-name": "^0.2.5"
   },

--- a/src/Context.js
+++ b/src/Context.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createReactContext from 'create-react-context';
+import createReactContext from 'mini-create-react-context';
 import name from 'react-display-name';
 
 export const YMapsContext = createReactContext(null);


### PR DESCRIPTION
Fixes #301

While peer deps were updated in #273, it was not enough actually since `create-react-context` peerDeps range is not updated. Now it should allow clear installation of React 17

Change is similar to ReactTraining/react-router#6692 so I believe `mini-create-react-context` is a drop-in replacement for an old library

I was unable to launch neither project itself or docz locally to test it, but my working project with updated bundles of `react-yandex-maps` worked well (e.g. YMap, YMaps components)
